### PR TITLE
add some requires in setup.py and add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.idea/
+*.pyc
+docs/_build
+*egg-info
+.tox
+.coverage
+venv
+dist
+build
+SpiderKeeper.db

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,20 @@ setup(
         'flask-restful-swagger==0.19',
         'Flask-SQLAlchemy==2.2',
         'PyMySQL==0.7.11',
-        'requests==2.13.0'
+        'requests==2.13.0',
+        'aniso8601==1.2.0',
+        'click==6.7',
+        'itsdangerous==0.24',
+        'Jinja2==2.9.6',
+        'MarkupSafe==1.0',
+        'PyMySQL==0.7.11',
+        'python-dateutil==2.6.0',
+        'pytz==2017.2',
+        'requests==2.13.0',
+        'six==1.10.0',
+        'SQLAlchemy',
+        'tzlocal',
+        'Werkzeug'
     ],
 
     entry_points={


### PR DESCRIPTION
When I run it by command `spiderkeeper --server=http://localhost:6800`, it response some error ：

> /Library/Python/2.7/site-packages/SpiderKeeper/app/__init__.py:8: ExtDeprecationWarning: Importing flask.ext.restful is deprecated, use flask_restful instead.
  from flask.ext.restful import Api
/Library/Python/2.7/site-packages/SpiderKeeper/app/__init__.py:9: ExtDeprecationWarning: Importing flask.ext.restful_swagger is deprecated, use flask_restful_swagger instead.
  from flask.ext.restful_swagger import swagger
/Library/Python/2.7/site-packages/SpiderKeeper/app/__init__.py:9: ExtDeprecationWarning: Importing flask.ext.restful_swagger.swagger is deprecated, use flask_restful_swagger.swagger instead.
  from flask.ext.restful_swagger import swagger
/Library/Python/2.7/site-packages/flask_restful_swagger/swagger.py:14: ExtDeprecationWarning: Importing flask.ext.restful.fields is deprecated, use flask_restful.fields instead.
  from flask.ext.restful import Resource, fields
/Library/Python/2.7/site-packages/flask_sqlalchemy/__init__.py:839: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
  'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
Traceback (most recent call last):
  File "/usr/local/bin/spiderkeeper", line 7, in <module>
    from SpiderKeeper.run import main
  File "/Library/Python/2.7/site-packages/SpiderKeeper/run.py", line 4, in <module>
    from SpiderKeeper.app import app, init_database, regist_server, start_scheduler
  File "/Library/Python/2.7/site-packages/SpiderKeeper/app/__init__.py", line 36, in <module>
    scheduler = BackgroundScheduler()
  File "/Library/Python/2.7/site-packages/apscheduler/schedulers/base.py", line 82, in __init__
    self.configure(gconfig, **options)
  File "/Library/Python/2.7/site-packages/apscheduler/schedulers/base.py", line 121, in configure
    self._configure(config)
  File "/Library/Python/2.7/site-packages/apscheduler/schedulers/background.py", line 29, in _configure
    super(BackgroundScheduler, self)._configure(config)
  File "/Library/Python/2.7/site-packages/apscheduler/schedulers/base.py", line 689, in _configure
    self.timezone = astimezone(config.pop('timezone', None)) or get_localzone()
  File "/Library/Python/2.7/site-packages/tzlocal/darwin.py", line 30, in get_localzone
    _cache_tz = _get_localzone()
  File "/Library/Python/2.7/site-packages/tzlocal/darwin.py", line 14, in _get_localzone
    stdout=subprocess.PIPE
AttributeError: __exit__

I found that it missing some dependencies in `setup.py`. So, I modify the `setup.py` and rebuild the `spiderkeeper`. 

Now it run successfully.