### PR TITLE
spider参数需要支持2个等号

### DIFF
--- a/SpiderKeeper/app/proxy/spiderctrl.py
+++ b/SpiderKeeper/app/proxy/spiderctrl.py
@@ -123,7 +123,7 @@ class SpiderAgent():
         spider_name = job_instance.spider_name
         arguments = {}
         if job_instance.spider_arguments:
-            arguments = dict(map(lambda x: x.split("="), job_instance.spider_arguments.split(",")))
+            arguments = dict(map(lambda x: x.split("=",1), job_instance.spider_arguments.split(",")))
         threshold = 0
         daemon_size = len(self.spider_service_instances)
         if job_instance.priority == JobPriority.HIGH:


### PR DESCRIPTION
$ curl http://localhost:6800/schedule.json -d project=myproject -d spider=somespider -d setting=DOWNLOAD_DELAY=2 -d arg1=val1

上面是scrapyd文档中schedule.json api的例子, 上面 -d setting=DOWNLOAD_DELAY=2这种参数需要在spiderkeeper的爬虫参数中设置为: setting=DOWNLOAD_DELAY=2, 现在代码是用=分割的, 是不正确的, 应该只分割第一个=