### PR TITLE
requests要求版本太老了, 改为>=2.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ MarkupSafe==1.0
 PyMySQL==0.7.11
 python-dateutil==2.6.0
 pytz==2017.2
-requests==2.13.0
+requests>=2.13.0
 six==1.10.0
 SQLAlchemy==1.1.9
 tzlocal==1.3


### PR DESCRIPTION
pipenv安装的时候和很多包有冲突, 比如influxdb-python要求requests版本>=2.17.0