### PR TITLE
Update spiderctrl.py

### DIFF
--- a/SpiderKeeper/app/proxy/spiderctrl.py
+++ b/SpiderKeeper/app/proxy/spiderctrl.py
@@ -127,7 +127,7 @@ class SpiderAgent():
         from collections import defaultdict
         arguments = defaultdict(list)
         if job_instance.spider_arguments:
-            for k, v in list(map(lambda x: x.split('=', 1).strip(), job_instance.spider_arguments.split(','))):
+            for k, v in list(map(lambda x: x.split('=', 1), map(lambda x: x.strip(), job_instance.spider_arguments.split(',')))):
                 arguments[k].append(v)
         threshold = 0
         daemon_size = len(self.spider_service_instances)

--- a/SpiderKeeper/app/proxy/spiderctrl.py
+++ b/SpiderKeeper/app/proxy/spiderctrl.py
@@ -127,7 +127,7 @@ class SpiderAgent():
         from collections import defaultdict
         arguments = defaultdict(list)
         if job_instance.spider_arguments:
-            for k, v in list(map(lambda x: x.split('=', 1), job_instance.spider_arguments.split(','))):
+            for k, v in list(map(lambda x: x.split('=', 1).strip(), job_instance.spider_arguments.split(','))):
                 arguments[k].append(v)
         threshold = 0
         daemon_size = len(self.spider_service_instances)


### PR DESCRIPTION
删除key两边的空行，否则填写args的时候，如果出现a=1, b=2这样的语句时，出现的key为'a', ' b'，第二个key会多个空格